### PR TITLE
fix: asm! => naked_asm! in naked functions; and format code

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use std::env;
-use std::process::Command;
 use std::path::PathBuf;
+use std::process::Command;
 
 fn aarch64_vfp_compile() {
     // 获取当前 crate 输出目录
@@ -12,10 +12,13 @@ fn aarch64_vfp_compile() {
     // 编译汇编文件，增加 target-feature 选项
     let status = Command::new("clang")
         .args(&[
-            "-c", asm_file.to_str().unwrap(),
-            "-o", asm_out_file.to_str().unwrap(),
-            "-target", "aarch64-unknown-none",
-            "-mfpu=neon"
+            "-c",
+            asm_file.to_str().unwrap(),
+            "-o",
+            asm_out_file.to_str().unwrap(),
+            "-target",
+            "aarch64-unknown-none",
+            "-mfpu=neon",
         ])
         .status()
         .expect("failed to execute clang");
@@ -24,7 +27,11 @@ fn aarch64_vfp_compile() {
     // 打包对象文件为静态库
     let lib_out_file = PathBuf::from(&out_dir).join("libvfp.a");
     let status = Command::new("ar")
-        .args(&["crus", lib_out_file.to_str().unwrap(), asm_out_file.to_str().unwrap()])
+        .args(&[
+            "crus",
+            lib_out_file.to_str().unwrap(),
+            asm_out_file.to_str().unwrap(),
+        ])
         .status()
         .expect("failed to execute ar");
     assert!(status.success(), "ar failed to create static library");

--- a/src/arch/aarch64.rs
+++ b/src/arch/aarch64.rs
@@ -113,6 +113,6 @@ pub unsafe extern "C" fn context_switch(_current_task: &mut TaskContext, _next_t
 }
 
 #[cfg(feature = "fp_simd")]
-extern "C"  {
+extern "C" {
     fn fpstate_switch(_current_fpstate: &mut FpState, _next_fpstate: &FpState);
 }

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,4 +1,4 @@
-use core::{arch::asm, fmt};
+use core::{arch::naked_asm, fmt};
 use memory_addr::VirtAddr;
 
 #[repr(C)]
@@ -143,12 +143,12 @@ impl TaskContext {
 
     pub fn thread_saved_fp(&self) -> usize {
         let frame_ptr = self.rsp as *const ContextSwitchFrame;
-        unsafe {(*frame_ptr).rbp as usize}
+        unsafe { (*frame_ptr).rbp as usize }
     }
 
     pub fn thread_saved_pc(&self) -> usize {
         let frame_ptr = self.rsp as *const ContextSwitchFrame;
-        unsafe {(*frame_ptr).rip as usize}
+        unsafe { (*frame_ptr).rip as usize }
     }
 }
 
@@ -159,7 +159,7 @@ impl TaskContext {
 ///
 /// This function is unsafe because it directly manipulates the CPU registers.
 pub unsafe extern "C" fn context_switch(_current_stack: &mut u64, _next_stack: &u64) {
-    asm!(
+    naked_asm!(
         "
         push    rbp
         push    rbx
@@ -177,6 +177,5 @@ pub unsafe extern "C" fn context_switch(_current_stack: &mut u64, _next_stack: &
         pop     rbx
         pop     rbp
         ret",
-        options(noreturn),
     )
 }

--- a/src/kstack.rs
+++ b/src/kstack.rs
@@ -15,8 +15,7 @@ extern "C" {
 
 impl TaskStack {
     pub fn new_init() -> Self {
-        let layout = 
-            Layout::from_size_align(axconfig::TASK_STACK_SIZE, 16).unwrap();
+        let layout = Layout::from_size_align(axconfig::TASK_STACK_SIZE, 16).unwrap();
         unsafe {
             Self {
                 ptr: NonNull::new(current_boot_stack()).unwrap(),

--- a/src/task.rs
+++ b/src/task.rs
@@ -486,7 +486,6 @@ impl TaskInner {
         unsafe { *status }
     }
 
-
     #[cfg(target_arch = "x86_64")]
     /// # Safety
     /// It is unsafe because it may cause undefined behavior if the `fs_base` is not a valid address.
@@ -555,7 +554,7 @@ impl TaskInner {
                 policy: SchedPolicy::SCHED_FIFO,
                 priority: 1,
             }),
-            
+
             #[cfg(feature = "monolithic")]
             is_vforked_child: AtomicBool::new(false),
         }
@@ -581,7 +580,7 @@ impl TaskInner {
             // FIXME: name 现已被用作 prctl 使用的程序名，应另选方式判断 idle 进程
             t.is_idle = true;
         }
-        t.kstack =  Some(TaskStack::new_init());
+        t.kstack = Some(TaskStack::new_init());
         t
     }
 
@@ -606,7 +605,10 @@ impl TaskInner {
     /// return ctx unwind
     #[inline]
     pub fn ctx_unwind(&self) -> (usize, usize) {
-        (self.get_ctx().thread_saved_pc(), self.get_ctx().thread_saved_fp())
+        (
+            self.get_ctx().thread_saved_pc(),
+            self.get_ctx().thread_saved_fp(),
+        )
     }
 
     /// Set the task waiting for reschedule


### PR DESCRIPTION
Current error:

```rust
error[E0787]: the `asm!` macro is not allowed in naked functions
   --> src/arch/x86_64.rs:162:5
    |
162 | /     asm!(
163 | |         "
164 | |         push    rbp
165 | |         push    rbx
...   |
180 | |         options(noreturn),
181 | |     )
    | |_____^ consider using the `naked_asm!` macro instead
```