### PR TITLE
fix: missing constants and AtomicU64 for --all-features on riscv32 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         rust-toolchain: [nightly, nightly-2024-12-04]
         targets: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, riscv32imafc-unknown-none-elf, aarch64-unknown-none-softfloat]
+        features: ["", "--all-features"]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
@@ -22,9 +23,9 @@ jobs:
     - name: Check code format
       run: cargo fmt --all -- --check
     - name: Clippy
-      run: cargo clippy --target ${{ matrix.targets }} --all-features
+      run: cargo clippy --target ${{ matrix.targets }} ${{ matrix.features }}
     - name: Build
-      run: cargo build --target ${{ matrix.targets }} --all-features
+      run: cargo build --target ${{ matrix.targets }} ${{ matrix.features }}
     - name: Unit test
       if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' }}
-      run: cargo test --target ${{ matrix.targets }} -- --nocapture
+      run: cargo test --target ${{ matrix.targets }} ${{ matrix.features }} -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Build & Check CI
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-toolchain: [nightly]
+        targets: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, riscv32imafc-unknown-none-elf, aarch64-unknown-none-softfloat]
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        toolchain: ${{ matrix.rust-toolchain }}
+        components: rust-src, clippy, rustfmt
+        targets: ${{ matrix.targets }}
+    - name: Check rust version
+      run: rustc --version --verbose
+    - name: Check code format
+      run: cargo fmt --all -- --check
+    - name: Clippy
+      run: cargo clippy --target ${{ matrix.targets }} --all-features
+    - name: Build
+      run: cargo build --target ${{ matrix.targets }} --all-features
+    - name: Unit test
+      if: ${{ matrix.targets == 'x86_64-unknown-linux-gnu' }}
+      run: cargo test --target ${{ matrix.targets }} -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust-toolchain: [nightly]
+        rust-toolchain: [nightly, nightly-2024-12-04]
         targets: [x86_64-unknown-linux-gnu, x86_64-unknown-none, riscv64gc-unknown-none-elf, riscv32imafc-unknown-none-elf, aarch64-unknown-none-softfloat]
     steps:
     - uses: actions/checkout@v4

--- a/src/arch/riscv.rs
+++ b/src/arch/riscv.rs
@@ -61,7 +61,7 @@ impl TaskContext {
 }
 
 macro_rules! save_and_restore {
-    ($LDR:literal, $STR:literal, $XLENB:literal) => {
+    (LDR = $LDR:literal, STR = $STR:literal, XLENB = $XLENB:literal) => {
         naked_asm!(concat!(
             r"
             .ifndef XLENB
@@ -122,8 +122,16 @@ macro_rules! save_and_restore {
 pub unsafe extern "C" fn context_switch(_current_task: &mut TaskContext, _next_task: &TaskContext) {
     unsafe {
         #[cfg(target_arch = "riscv32")]
-        save_and_restore!(r"lw  \rd, \off*XLENB(\rs)", r"sw \rs2, \off*XLENB(\rs1)", 4);
+        save_and_restore!(
+            LDR = r"lw  \rd, \off*XLENB(\rs)",
+            STR = r"sw \rs2, \off*XLENB(\rs1)",
+            XLENB = 4
+        );
         #[cfg(target_arch = "riscv64")]
-        save_and_restore!(r"ld  \rd, \off*XLENB(\rs)", r"sd \rs2, \off*XLENB(\rs1)", 8);
+        save_and_restore!(
+            LDR = r"ld  \rd, \off*XLENB(\rs)",
+            STR = r"sd \rs2, \off*XLENB(\rs1)",
+            XLENB = 8
+        );
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -65,7 +65,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_arch = "aarch64")] {
         const TCB_SIZE: usize = 0;
         const GAP_ABOVE_TP: usize = 16;
-    } else if #[cfg(target_arch = "riscv64")] {
+    } else if #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))] {
         const TCB_SIZE: usize = 0;
         const GAP_ABOVE_TP: usize = 0;
     }


### PR DESCRIPTION
For context: https://github.com/Starry-OS/taskctx/pull/10#issuecomment-2566097330

This PR includes

1. fixing missing constants like TCB_SIZE
2. replacing u64 with usize in fields of TaskId and TaskInner: all changes are
 
* struct TaskId(u64) => struct TaskId(usize)
* static ID_COUNTER: AtomicU64 => static ID_COUNTER: AtomicUsize
* process_id: AtomicU64 => process_id: AtomicUsize
* set_child_tid: AtomicU64 => set_child_tid: AtomicUsize
* clear_child_tid: AtomicU64 => clear_child_tid: AtomicUsize
* cpu_set: AtomicU64 => cpu_set: AtomicUsize

3. setting up CI for all targets and all features: it's weird there are errors saying `unrecognized instruction mnemonic` for riscv code on [latest nightly rustc](https://github.com/os-checker/taskctx/actions/runs/12556003791/job/35006699477), but no error on a bit older toolchain [nightly-2024-12-04](https://github.com/os-checker/taskctx/actions/runs/12556003791/job/35006699867#logs). This has been reported to Rust repo https://github.com/rust-lang/rust/issues/134960 .

![截图_20241231134510](https://github.com/user-attachments/assets/7ff71132-e0e4-44b5-8701-adcd02ebd26a)
